### PR TITLE
Use highlight library instead of highlight-regexp

### DIFF
--- a/evil-search-highlight-persist.el
+++ b/evil-search-highlight-persist.el
@@ -3,6 +3,7 @@
 
 ;; Author: Juanjo Alvarez <juanjo@juanjoalvarez.net>
 ;; Created:  September 18, 2014
+;; Package-Requires: ((highlight "0"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -42,6 +43,7 @@
 
 ;;; User Customizable Variables:
 (require 'advice)
+(require 'highlight)
 
 (defgroup evil-search-highlight-persist nil
   "evil-search-highlight-persist -- Search Highlight Remain, Vim's style"
@@ -58,15 +60,16 @@
 
 (defun evil-search-highlight-persist-remove-all ()
   (interactive)
-  (hi-lock-mode -1)
-  (hi-lock-mode 1))
+  (hlt-unhighlight-region-in-buffers (list (current-buffer))))
 
 (defun evil-search-highlight-persist-mark ()
-  (highlight-regexp
-    (car-safe (if isearch-regexp
-                regexp-search-ring
-                search-ring))
-    (face-name 'evil-search-highlight-persist-highlight-face)))
+  (let ((hlt-use-overlays-flag t)
+        (hlt-last-face 'evil-search-highlight-persist-highlight-face))
+    (hlt-highlight-regexp-region-in-buffers
+     (car-safe (if isearch-regexp
+                   regexp-search-ring
+                 search-ring))
+     (list (current-buffer)))))
 
 (defadvice isearch-exit (after isearch-highlight-persist)
   (evil-search-highlight-persist-remove-all)


### PR DESCRIPTION
Hi Juanjo,

This PR uses [highlight.el](http://www.emacswiki.org/emacs/?action=browse;oldid=HighLight;id=HighlightLibrary) library instead of `highlight-regexp`.
This allows to easily use `overlays` instead of `font-locking` which play nicer with `hl-line-mode` and `global-hl-line-mode`.

_Before_
![capture d ecran 2014-11-12 a 22 24 40](https://cloud.githubusercontent.com/assets/1243537/5022982/9a5e87e0-6abc-11e4-9255-36d0ade4c6d6.png)

_After_
![capture d ecran 2014-11-12 a 22 18 28](https://cloud.githubusercontent.com/assets/1243537/5022985/a26b5c56-6abc-11e4-9765-fd70ecff3683.png)

Cheers,
syl20bnr
