### PR TITLE
Don't enable the mode when major mode is fundamental

### DIFF
--- a/evil-search-highlight-persist.el
+++ b/evil-search-highlight-persist.el
@@ -106,7 +106,8 @@
 ;;;###autoload
 (defun turn-on-search-highlight-persist ()
   "Enable search-highlight-persist in the current buffer."
-  (evil-search-highlight-persist 1))
+  (evil-search-highlight-persist
+   (if (eq 'fundamental-mode major-mode) -1 1)))
 
 ;;;###autoload
 (defun turn-off-search-highlight-persist ()


### PR DESCRIPTION
Hi Juan,

It better follows the emacs guideline telling that we should not customize the fundamental mode.
Moreover it fixes a big performance issue when searching in very large files.

Cheers,
syl20bnr