### PR TITLE
Fix byte-compile warnings about free variables

### DIFF
--- a/evil-search-highlight-persist.el
+++ b/evil-search-highlight-persist.el
@@ -49,7 +49,7 @@
 (require 'advice)
 (require 'highlight)
 
-(setq evil-search-highlight-regex-flag t)
+(defvar evil-search-highlight-regex-flag t)
 (defun hlt-+/--highlight-regexp-region (unhighlightp start end regexp face msgp mousep nth &optional buffers)
   "Helper for `hlt-(un)highlight-regexp-region'.
 Non-nil UNHIGHLIGHTP means unhighlight.  Otherwise, highlight.
@@ -154,8 +154,8 @@ really want to highlight up to %d chars?  "
 (defvar evil-search-highlight-string-min-len 1 "min legth")
 (defun evil-search-highlight-persist-mark ()
   (let ((hlt-use-overlays-flag t)
-        (hlt-last-face 'evil-search-highlight-persist-highlight-face))
-    (setq tmp nil)
+        (hlt-last-face 'evil-search-highlight-persist-highlight-face)
+        tmp)
     (if isearch-regexp
         (progn
           (setq tmp (car-safe regexp-search-ring))


### PR DESCRIPTION
- Use defvar for declaring global variable
- Declare temporary variable as local variable